### PR TITLE
Avoid manual path construction

### DIFF
--- a/src/Console/MigrateMakeCommand.php
+++ b/src/Console/MigrateMakeCommand.php
@@ -25,8 +25,8 @@ class MigrateMakeCommand extends Command
     {
         // Needed for Laravel 6 and 7 support. Laravel 8 handles creating folder automatically
         // @codeCoverageIgnoreStart
-        if (! file_exists(database_path('content-migrations')) {
-            mkdir(database_path('content-migrations'), 0755));
+        if (! file_exists(database_path('content-migrations'))) {
+            mkdir(database_path('content-migrations'), 0755);
         }
         // @codeCoverageIgnoreEnd
 

--- a/src/Console/MigrateMakeCommand.php
+++ b/src/Console/MigrateMakeCommand.php
@@ -25,8 +25,8 @@ class MigrateMakeCommand extends Command
     {
         // Needed for Laravel 6 and 7 support. Laravel 8 handles creating folder automatically
         // @codeCoverageIgnoreStart
-        if (! file_exists(database_path() . DIRECTORY_SEPARATOR . 'content-migrations')) {
-            mkdir(database_path() . DIRECTORY_SEPARATOR . 'content-migrations');
+        if (! file_exists(database_path('content-migrations')) {
+            mkdir(database_path('content-migrations'), 0755);
         }
         // @codeCoverageIgnoreEnd
 

--- a/src/Console/MigrateMakeCommand.php
+++ b/src/Console/MigrateMakeCommand.php
@@ -26,7 +26,7 @@ class MigrateMakeCommand extends Command
         // Needed for Laravel 6 and 7 support. Laravel 8 handles creating folder automatically
         // @codeCoverageIgnoreStart
         if (! file_exists(database_path('content-migrations')) {
-            mkdir(database_path('content-migrations'), 0755);
+            mkdir(database_path('content-migrations'), 0755));
         }
         // @codeCoverageIgnoreEnd
 


### PR DESCRIPTION
`database_path` accepts subdirectory path as argument so you can avoid manual path construction.

Also [documentation](https://www.php.net/manual/en/function.mkdir.php) says that `The mode is 0777 by default, which means the widest possible access.` so it's better to specify narrower permissions. Thought you may want to merge this change separately.
